### PR TITLE
Remove a deprecated method from `importlib_metadata`

### DIFF
--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 __requires__ = [
-    'importlib-metadata>=3.9.0; python_version<"3.8"',
+    'importlib-metadata>=3.6.0; python_version<"3.8"',
     'importlib-resources>=1.1.0; python_version<"3.9"',
     "traits>=6.2"
 ]

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 __requires__ = [
-    'importlib-metadata; python_version<"3.8"',
+    'importlib-metadata>=3.9.0; python_version<"3.8"',
     'importlib-resources>=1.1.0; python_version<"3.9"',
     "traits>=6.2"
 ]

--- a/pyface/__init__.py
+++ b/pyface/__init__.py
@@ -19,7 +19,7 @@ except ImportError:
 
 
 __requires__ = [
-    'importlib-metadata>=3.6.0; python_version<"3.8"',
+    'importlib-metadata>=3.6.0; python_version<"3.10"',
     'importlib-resources>=1.1.0; python_version<"3.9"',
     "traits>=6.2"
 ]

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -187,7 +187,7 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
         If no toolkit is found, or if the toolkit cannot be loaded for some
         reason.
     """
-    entry_point_group = importlib_metadata.entry_points().select(entry_point)
+    entry_point_group = importlib_metadata.entry_points().select(group=entry_point)
     plugins = [
         plugin for plugin in entry_point_group if plugin.name == toolkit_name
     ]

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -256,7 +256,7 @@ def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
         return import_toolkit(ETSConfig.toolkit, entry_point)
 
     entry_points = [
-        plugin for plugin in importlib_metadata.entry_points().select(entry_point)
+        plugin for plugin in importlib_metadata.entry_points().select(group=entry_point)
         if toolkits is None or plugin.name in toolkits
     ]
     for plugin in sorted(entry_points, key=priorities):

--- a/pyface/base_toolkit.py
+++ b/pyface/base_toolkit.py
@@ -187,7 +187,7 @@ def import_toolkit(toolkit_name, entry_point="pyface.toolkits"):
         If no toolkit is found, or if the toolkit cannot be loaded for some
         reason.
     """
-    entry_point_group = importlib_metadata.entry_points()[entry_point]
+    entry_point_group = importlib_metadata.entry_points().select(entry_point)
     plugins = [
         plugin for plugin in entry_point_group if plugin.name == toolkit_name
     ]
@@ -256,7 +256,7 @@ def find_toolkit(entry_point, toolkits=None, priorities=default_priorities):
         return import_toolkit(ETSConfig.toolkit, entry_point)
 
     entry_points = [
-        plugin for plugin in importlib_metadata.entry_points()[entry_point]
+        plugin for plugin in importlib_metadata.entry_points().select(entry_point)
         if toolkits is None or plugin.name in toolkits
     ]
     for plugin in sorted(entry_points, key=priorities):


### PR DESCRIPTION
It removes a deprecated feature from `importlib_metadata`. See the reference here: https://importlib-metadata.readthedocs.io/en/latest/history.html#v3-9-0.